### PR TITLE
feat: 实现 GitHub PR 逐文件详细代码审查

### DIFF
--- a/api/services/llm_review_detailed_service.py
+++ b/api/services/llm_review_detailed_service.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from openai import OpenAI # Ensure OpenAI client is available for type hinting if needed
 from api.core_config import app_configs
 from .llm_client_manager import get_openai_client, execute_llm_chat_completion
 
@@ -251,3 +252,93 @@ def get_openai_code_review(structured_file_changes):
         final_json_output = "[]"
 
     return final_json_output
+
+
+def get_openai_detailed_review_for_file(file_path: str, file_data: dict, client: OpenAI, model_name: str):
+    """
+    使用 OpenAI API 对单个文件的结构化代码变更进行详细审查。
+    返回一个 Python 列表，其中包含该文件的审查意见字典。
+    如果文件没有问题或发生错误，则返回空列表。
+    """
+    if not client:
+        logger.warning(f"OpenAI 客户端不可用 (传递给 get_openai_detailed_review_for_file 时)。跳过文件 {file_path} 的审查。")
+        return []
+    if not file_data:
+        logger.info(f"未提供文件 {file_path} 的数据以供详细审查。")
+        return []
+
+    input_data = {
+        "file_meta": {
+            "path": file_data.get("path", file_path), # Ensure path from file_data or argument
+            "old_path": file_data.get("old_path"),
+            "lines_changed": file_data.get("lines_changed", len(file_data.get("changes", []))),
+            "context": file_data.get("context", {})
+        },
+        "changes": file_data.get("changes", [])
+    }
+    try:
+        input_json_string = json.dumps(input_data, indent=2, ensure_ascii=False)
+    except TypeError as te:
+        logger.error(f"序列化文件 {file_path} 的输入数据时出错: {te}")
+        logger.error(f"有问题的输入结构: {input_data}")
+        return []
+
+    user_prompt_for_llm = f"\n\n```json\n{input_json_string}\n```\n"
+
+    try:
+        logger.info(f"正在发送文件审查请求 (详细): {file_path} 给模型 {model_name}...")
+        
+        review_json_str = execute_llm_chat_completion(
+            client,
+            model_name,
+            DETAILED_REVIEW_SYSTEM_PROMPT,
+            user_prompt_for_llm,
+            f"文件 {file_path} 的细粒度审查",
+            response_format_type="json_object"
+        )
+
+        logger.info(f"-------------LLM 输出 (文件: {file_path})-----------")
+        logger.info(f"{review_json_str}")
+        logger.info(f"-------------LLM 输出结束 (文件: {file_path})-----------")
+
+        try:
+            parsed_output = json.loads(review_json_str)
+            reviews_for_this_file = []
+            if isinstance(parsed_output, list):
+                reviews_for_this_file = parsed_output
+            elif isinstance(parsed_output, dict):
+                found_list = False
+                for key, value in parsed_output.items():
+                    if isinstance(value, list):
+                        reviews_for_this_file = value
+                        found_list = True
+                        logger.info(f"在 LLM 输出的键 '{key}' 下找到文件 {file_path} 的审查列表。")
+                        break
+                if not found_list:
+                    logger.warning(
+                        f"警告: 文件 {file_path} 的 LLM 输出是一个字典，但未找到列表值。输出: {review_json_str}")
+                    reviews_for_this_file = [parsed_output] # Try to treat as single item
+            else:
+                logger.warning(
+                    f"警告: 文件 {file_path} 的 LLM 输出不是 JSON 列表或预期的字典。输出: {review_json_str}")
+                return [] # Not a valid format
+
+            valid_reviews = []
+            for review in reviews_for_this_file:
+                if isinstance(review, dict) and all(
+                        k in review for k in ["file", "lines", "category", "severity", "analysis", "suggestion"]):
+                    if review.get("file") != file_path:
+                        logger.warning(f"警告: 修正审查中的文件路径从 '{review.get('file')}' 为 '{file_path}' (针对文件 {file_path})")
+                        review["file"] = file_path
+                    valid_reviews.append(review)
+                else:
+                    logger.warning(f"警告: 跳过文件 {file_path} 的无效审查项结构: {review}")
+            return valid_reviews
+
+        except json.JSONDecodeError as json_e:
+            logger.error(f"错误: 解析来自 OpenAI 的文件 {file_path} 的 JSON 响应失败: {json_e}")
+            logger.error(f"LLM 原始输出为: {review_json_str}")
+            return []
+    except Exception as e:
+        logger.exception(f"从 OpenAI 获取文件 {file_path} 的详细代码审查时出错:")
+        return []

--- a/api/services/llm_service.py
+++ b/api/services/llm_service.py
@@ -8,7 +8,7 @@ from .llm_client_manager import (
 )
 
 # 从 llm_review_detailed_service 导入
-from .llm_review_detailed_service import get_openai_code_review
+from .llm_review_detailed_service import get_openai_code_review, get_openai_detailed_review_for_file
 
 # 从 llm_review_general_service 导入
 from .llm_review_general_service import get_openai_code_review_general
@@ -21,7 +21,8 @@ __all__ = [
     "initialize_openai_client",
     "get_openai_client",
     "get_openai_code_review",
+    "get_openai_detailed_review_for_file", # 新增导出
     "get_openai_code_review_general",
 ]
 
-logger.info("LLM 服务外观已初始化，将重定向到专门的服务。")
+logger.info("LLM 服务已初始化，将重定向到专门的服务。")


### PR DESCRIPTION
重构 GitHub 详细代码审查逻辑，改为逐文件调用 LLM 进行审查。
- 新增 `get_openai_detailed_review_for_file` 函数，用于处理单个文件的代码变更。
- 修改 GitHub webhook 处理函数，遍历 PR 中的每个文件，调用新函数获取审查意见。
- 对每个文件返回的审查意见，尝试作为单独的评论发布到 GitHub PR 中。
- 收集所有文件的审查意见，统一保存到 Redis。
- 保留原有的 `get_openai_code_review` 函数，供 GitLab 详细审查使用。